### PR TITLE
task: email configuration settings

### DIFF
--- a/uipa_org/settings/base.py
+++ b/uipa_org/settings/base.py
@@ -9,8 +9,18 @@ from pathlib import Path
 
 rec = lambda x: re.compile(x, re.I | re.U)
 
+# Helper functions for reading environment variables
+
+# env() returns the value of an environment variable, or None if it is not set
 def env(key, default=None):
     return os.environ.get(key, default)
+
+# required_env() returns the value of an environment variable, or raises an exception if it is not set
+def required_env(key):
+    value = env(key)
+    if value is None or value == "":
+        raise ValueError(f"Required environment variable {key} is not set")
+    return value
 
 THEME_ROOT = Path(__file__).resolve().parent.parent
 

--- a/uipa_org/settings/development.py
+++ b/uipa_org/settings/development.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .base import UipaOrgThemeBase, env
+from .base import UipaOrgThemeBase, env, required_env
 
 class Dev(UipaOrgThemeBase):
     DEBUG = True
@@ -25,7 +25,7 @@ class Dev(UipaOrgThemeBase):
     ENABLE_EMAIL = env("ENABLE_EMAIL", False)
     
     if ENABLE_EMAIL:
-        SERVER_EMAIL = env("SERVER_EMAIL") # This is the inbound address for the SMTP server (i.e. ...@inbound.postmarkapp.com)
+        SERVER_EMAIL = required_env("SERVER_EMAIL") # This is the inbound address for the SMTP server (i.e. ...@inbound.postmarkapp.com)
         DEFAULT_FROM_EMAIL = env(
             "DEFAULT_FROM_EMAIL", "TEST UIPA.org <test@beta.uipa.org>"
         )
@@ -33,26 +33,26 @@ class Dev(UipaOrgThemeBase):
         EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend' # This will be different for production
         
         # These settings are for sending regular email notifications (not FOI requests to public bodies)
-        EMAIL_HOST = env("EMAIL_HOST") # This is the SMTP server for sending mail (i.e. smtp.postmarkapp.com)
+        EMAIL_HOST = required_env("EMAIL_HOST") # This is the SMTP server for sending mail (i.e. smtp.postmarkapp.com)
         EMAIL_PORT = env("EMAIL_PORT", 2525)
-        EMAIL_HOST_USER = env("EMAIL_HOST_USER") # This is the username for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012) - this is the same as the password
-        EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD") # This is the password for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012)
+        EMAIL_HOST_USER = required_env("EMAIL_HOST_USER") # This is the username for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012) - this is the same as the password
+        EMAIL_HOST_PASSWORD = required_env("EMAIL_HOST_PASSWORD") # This is the password for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012)
         EMAIL_USE_TLS = env("EMAIL_USE_TLS", True)
         
         # These settings are for sending FOI requests to public bodies
         FOI_EMAIL_FIXED_FROM_ADDRESS = env("FOI_EMAIL_FIXED_FROM_ADDRESS", True)
-        FOI_EMAIL_HOST_USER = env("FOI_EMAIL_HOST_USER") # This is the username for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012) - this is the same as the password
-        FOI_EMAIL_HOST_PASSWORD = env("FOI_EMAIL_HOST_PASSWORD") # This is the password for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012)
-        FOI_EMAIL_HOST = env("FOI_EMAIL_HOST") # This is the SMTP server for sending mail (i.e. smtp.postmarkapp.com)
+        FOI_EMAIL_HOST_USER = required_env("FOI_EMAIL_HOST_USER") # This is the username for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012) - this is the same as the password
+        FOI_EMAIL_HOST_PASSWORD = required_env("FOI_EMAIL_HOST_PASSWORD") # This is the password for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012)
+        FOI_EMAIL_HOST = required_env("FOI_EMAIL_HOST") # This is the SMTP server for sending mail (i.e. smtp.postmarkapp.com)
         FOI_EMAIL_PORT = env("FOI_EMAIL_PORT", 2525)
         FOI_EMAIL_USE_TLS = env("FOI_EMAIL_USE_TLS", True)
         
         # These settings are for receiving FOI responses from public bodies
-        FOI_EMAIL_HOST_FROM = env("FOI_EMAIL_HOST_FROM") # This is the inbound address for the SMTP server (i.e. ...@inbound.postmarkapp.com)
+        FOI_EMAIL_HOST_FROM = required_env("FOI_EMAIL_HOST_FROM") # This is the inbound address for the SMTP server (i.e. ...@inbound.postmarkapp.com)
         # When defining the "FOI_EMAIL_DOMAIN" setting for testing, Postmark enforces that all recipient addresses must share the same domain as the inbound address.
         # Basically, if your email address ends in @example.com, then the "FOI_EMAIL_DOMAIN" setting must be set to "example.com".
-        FOI_EMAIL_DOMAIN = env("FOI_EMAIL_DOMAIN") # This defines the "From" address for the inbound email (i.e. beta-foi.uipa.org)
-        FOI_MAIL_SERVER_HOST = env("FOI_MAIL_SERVER_HOST") # This defines the "Message-Id" header for the inbound email (i.e. beta-foi.uipa.org)
+        FOI_EMAIL_DOMAIN = required_env("FOI_EMAIL_DOMAIN") # This defines the "From" address for the inbound email (i.e. beta-foi.uipa.org)
+        FOI_MAIL_SERVER_HOST = required_env("FOI_MAIL_SERVER_HOST") # This defines the "Message-Id" header for the inbound email (i.e. beta-foi.uipa.org)
         
         # End of email settings
 

--- a/uipa_org/settings/development.py
+++ b/uipa_org/settings/development.py
@@ -13,3 +13,46 @@ class Dev(UipaOrgThemeBase):
         TEMP = super().TEMPLATES
         TEMP[0]["OPTIONS"]["debug"] = True
         return TEMP
+    
+    # Start of email settings
+    # Read the docs about these settings here: https://github.com/okfde/froide/blob/2dc1899cfe732c3f1d658f07ca86626dd5baa1a3/docs/configuration.rst#settings-for-sending-e-mail
+    # The exact settings can be seen https://github.com/okfde/froide/blob/2dc1899cfe732c3f1d658f07ca86626dd5baa1a3/froide/settings.py#L618
+    
+    # General email settings
+    # This is the feature flag for enabling email sending & receiving
+    # This should be done with caution as it can lead to sending out emails to real public bodies
+    # It is recommended to create a test public body for testing purposes, so that real public bodies are not contacted
+    ENABLE_EMAIL = env("ENABLE_EMAIL", False)
+    
+    if ENABLE_EMAIL:
+        SERVER_EMAIL = env("SERVER_EMAIL") # This is the inbound address for the SMTP server (i.e. ...@inbound.postmarkapp.com)
+        DEFAULT_FROM_EMAIL = env(
+            "DEFAULT_FROM_EMAIL", "TEST UIPA.org <test@beta.uipa.org>"
+        )
+        EMAIL_SUBJECT_PREFIX = env("EMAIL_SUBJECT_PREFIX", "[TEST UIPA.org] ")
+        EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend' # This will be different for production
+        
+        # These settings are for sending regular email notifications (not FOI requests to public bodies)
+        EMAIL_HOST = env("EMAIL_HOST") # This is the SMTP server for sending mail (i.e. smtp.postmarkapp.com)
+        EMAIL_PORT = env("EMAIL_PORT", 2525)
+        EMAIL_HOST_USER = env("EMAIL_HOST_USER") # This is the username for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012) - this is the same as the password
+        EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD") # This is the password for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012)
+        EMAIL_USE_TLS = env("EMAIL_USE_TLS", True)
+        
+        # These settings are for sending FOI requests to public bodies
+        FOI_EMAIL_FIXED_FROM_ADDRESS = env("FOI_EMAIL_FIXED_FROM_ADDRESS", True)
+        FOI_EMAIL_HOST_USER = env("FOI_EMAIL_HOST_USER") # This is the username for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012) - this is the same as the password
+        FOI_EMAIL_HOST_PASSWORD = env("FOI_EMAIL_HOST_PASSWORD") # This is the password for the SMTP server (i.e. 12345678-1234-1234-1234-123456789012)
+        FOI_EMAIL_HOST = env("FOI_EMAIL_HOST") # This is the SMTP server for sending mail (i.e. smtp.postmarkapp.com)
+        FOI_EMAIL_PORT = env("FOI_EMAIL_PORT", 2525)
+        FOI_EMAIL_USE_TLS = env("FOI_EMAIL_USE_TLS", True)
+        
+        # These settings are for receiving FOI responses from public bodies
+        FOI_EMAIL_HOST_FROM = env("FOI_EMAIL_HOST_FROM") # This is the inbound address for the SMTP server (i.e. ...@inbound.postmarkapp.com)
+        # When defining the "FOI_EMAIL_DOMAIN" setting for testing, Postmark enforces that all recipient addresses must share the same domain as the inbound address.
+        # Basically, if your email address ends in @example.com, then the "FOI_EMAIL_DOMAIN" setting must be set to "example.com".
+        FOI_EMAIL_DOMAIN = env("FOI_EMAIL_DOMAIN") # This defines the "From" address for the inbound email (i.e. beta-foi.uipa.org)
+        FOI_MAIL_SERVER_HOST = env("FOI_MAIL_SERVER_HOST") # This defines the "Message-Id" header for the inbound email (i.e. beta-foi.uipa.org)
+        
+        # End of email settings
+


### PR DESCRIPTION
# Context

This pull requests enables the sending of FOI emails to public bodies.

# Testing

> Note: Brian has sent me the previous Postmark credentials, if you want to test this PR (and enable the sending of emails) reach out to me on Slack (codewithaloha.slack.com) and I shall provide them to you.

When testing this, both the `ENABLE_EMAIL` and the other related email configuration environment variables need to be set (depending on what you are trying to test). You should also not send a test email to a "real" public body on the development portal, as that will actually send a real email to that entity. You should create some sort of test public body and send all emails to that test entity.

**Example FOI Email Received**

![Screenshot 2024-04-06 at 1 26 14 PM](https://github.com/CodeWithAloha/uipa/assets/15609358/63a36f57-a56f-46cb-b587-969d1d6fbbfe)

# Related Items

https://github.com/CodeWithAloha/uipa/issues/89
