### PR TITLE
docs: refactor docs/ directory and add email setup docs

### DIFF
--- a/docs/Emails.md
+++ b/docs/Emails.md
@@ -7,7 +7,7 @@ This document describes the email setup process for the UIPA.org project. At the
 Before you start, you need to have the following:
 - A working development environment for the project (Follow the [Getting Started](https://github.com/CodeWithAloha/uipa?tab=readme-ov-file#getting-started) guide to set this up)
 - [The required email related environment variables](https://github.com/CodeWithAloha/uipa/blob/3bcbd67a8102b62840128017b4d62112b74e4d4c/uipa_org/settings/development.py#L25) (e.g., `ENABLE_EMAIL`, `SERVER_EMAIL`, `EMAIL_HOST`, ...etc.)
-- - You can reach out to @tyliec for shared values of these environment variables, or you can utilize another email server (using something like https://postmarkapp.com/) and set those values yourself.
+- - You can reach out to @tyliec or in the `#project-uipa` channel for shared values of these environment variables, or you can utilize another email server (using something like https://postmarkapp.com/) and set those values yourself.
 - - Setting these values would look something like `export EMAIL_HOST='smtp.postmarkapp.com'` in your terminal.
 
 # Context

--- a/docs/Emails.md
+++ b/docs/Emails.md
@@ -1,0 +1,38 @@
+# Emails
+
+This document describes the email setup process for the UIPA.org project. At the end of this document, you will have a working email setup for the project (be able to send both FOI and general emails).
+
+## Prerequisites
+
+Before you start, you need to have the following:
+- A working development environment for the project (Follow the [Getting Started](https://github.com/CodeWithAloha/uipa?tab=readme-ov-file#getting-started) guide to set this up)
+- [The required email related environment variables](https://github.com/CodeWithAloha/uipa/blob/3bcbd67a8102b62840128017b4d62112b74e4d4c/uipa_org/settings/development.py#L25) (e.g., `ENABLE_EMAIL`, `SERVER_EMAIL`, `EMAIL_HOST`, ...etc.)
+- - You can reach out to @tyliec for shared values of these environment variables, or you can utilize another email server (using something like https://postmarkapp.com/) and set those values yourself.
+- - Setting these values would look something like `export EMAIL_HOST='smtp.postmarkapp.com'` in your terminal.
+
+# Context
+
+There are two types of emails that the project sends:
+- General emails: These are emails that are sent for administrative purposes (e.g., account creation, password reset, etc.)
+- FOI emails: These are emails that are sent when a form is submitted to send a Freedom of Information (FOI) request to a public agency.
+
+# Walkthrough
+
+After you have the prerequisites set up, you can follow the steps below to verify that your email setup is working.
+- **IMPORTANT**: Once you have your email server set up, it is highly possible that you might accidentially send an email to a real email address/public body. To avoid this, you should create a test public body and use that test public body's email address for testing purposes.
+
+## General Emails
+
+To test general emails, you can generate/trigger a data export. This will send a URL to download the data export to the email address of the user who triggered the export. You can trigger a data export by following these steps:
+- Go to Profile > Settings
+- Click on the "Request Data Export" button
+
+## FOI Emails
+
+- **IMPORTANT**: Once you have your email server set up, it is highly possible that you might accidentially send an email to a real email address/public body. To avoid this, you should create a test public body and use that test public body's email address for testing purposes.
+
+To test FOI emails, you can submit a FOI request to a public body. You can do this by following these steps:
+- Go to the public body's page
+- Click the "Make a Request to this Public Body!" button
+- Fill out the form and submit it
+- A FOI email should be sent to the public body's email address (please ensure that the email address is correct and that the email is not sent to a real public body if you are just testing)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Docs
+
+This directory contains the documentation for the UIPA.org project.
+
+## Table of Contents
+
+- Seeding the Database (inserting public bodies data) - [Seeding](Seeding.md)
+- Setting up Emails - [Emails](Emails.md)

--- a/docs/Seeding.md
+++ b/docs/Seeding.md
@@ -1,7 +1,6 @@
 # Seeding the Database
 
-This covers seeding the database for development work.
-
+This covers seeding the database of public bodies for development work. "Public bodies" or "Public agencies" is the monicker for government agencies that are subject to the Uniform Information Practices Act (UIPA) in Hawaii. These include organizations such as the Department of Land & Natural Resources, Department of Planning & Permitting, and the Office of Information Practices.
 
 ## Preparation
 
@@ -24,6 +23,7 @@ be in your working directory with the UIPA.org source files cloned from your
 fork of the main branch of the [UIPA.org
 repository](https://github.com/CodeWithAloha/uipa).
 
+The context of the following commands should be run in the `data/seed` directory, rather than the `docs` directory.
 
 ## Seeding
 

--- a/docs/Seeding.md
+++ b/docs/Seeding.md
@@ -1,6 +1,6 @@
 # Seeding the Database
 
-This covers seeding the database of public bodies for development work. "Public bodies" or "Public agencies" is the monicker for government agencies that are subject to the Uniform Information Practices Act (UIPA) in Hawaii. These include organizations such as the Department of Land & Natural Resources, Department of Planning & Permitting, and the Office of Information Practices.
+This covers seeding the database of public bodies for development work. "Public bodies" or "Public agencies" means government agencies that are subject to the Uniform Information Practices Act (UIPA) in Hawaii. These include organizations such as the Department of Land & Natural Resources, Department of Planning & Permitting, and the Office of Information Practices.
 
 ## Preparation
 
@@ -23,9 +23,9 @@ be in your working directory with the UIPA.org source files cloned from your
 fork of the main branch of the [UIPA.org
 repository](https://github.com/CodeWithAloha/uipa).
 
-The context of the following commands should be run in the `data/seed` directory, rather than the `docs` directory.
-
 ## Seeding
+
+> Note: The commands in this section should be run in the top level of the working directory where the `manage.py` file is located.
 
 ### Load Classifications, Jurisdictions, and Freedom of Information Laws
 


### PR DESCRIPTION
- Moves the `data/seed/Seeding.md` file into `docs/Seeding.md`.
- Adds a ToC (Table of Contents) to the `docs/` directory-
- Adds instructions for creating up a working email setup
